### PR TITLE
Making it a little bit more idiomatic and a little less error prone

### DIFF
--- a/haskell_excercises.hs
+++ b/haskell_excercises.hs
@@ -20,7 +20,7 @@ afterFilter _ [] = []
 afterFilter _ [_] = []
 afterFilter f (x:y:xs)
   | f x = y : afterFilter f xs
-  | otherwise = x : afterFilter f (y:xs)
+  | otherwise = afterFilter f (y:xs)
 
 -- 2015 Autumn
 revCount :: [a] -> [Int] -> [a]

--- a/haskell_excercises.hs
+++ b/haskell_excercises.hs
@@ -12,27 +12,28 @@ sort pred (x:xs) =
 mapEveryOther :: (a -> a) -> [a] -> [a]
 mapEveryOther _ [] = []
 mapEveryOther f [x] = [f x]
-mapEveryOther f (x:y:xs) =
-  [f x] ++ [y] ++ mapEveryOther f xs
-
+mapEveryOther f (x:y:xs) = f x : y : mapEveryOther f xs
 
 -- 2015 January
 afterFilter :: (a -> Bool) -> [a] -> [a]
 afterFilter _ [] = []
+afterFilter _ [_] = []
 afterFilter f (x:y:xs)
-  | f x = [y] ++ afterFilter f xs
-  | otherwise = [x] ++ afterFilter f nxs
-    where
-      nxs = [y] ++ xs
+  | f x = y : afterFilter f xs
+  | otherwise = x : afterFilter f (y:xs)
 
 -- 2015 Autumn
-revCount :: [Char] -> [Int] -> [[Char]]
-revCount letters numbers = reverse $ zipWith (replicate) numbers letters
+revCount :: [a] -> [Int] -> [a]
+revCount letters numbers = concatMap reverse $ zipWith replicate numbers letters
 
-revCount' :: [Char] -> [Int] -> [Char]
+revCount' :: [a] -> [Int] -> [a]
+revCount' [] _ = []
 revCount' _ [] = []
-revCount' (c:cs) (n:ns) = (revCount' cs ns) ++ (repeat' c n)
+revCount' (c:cs) (n:ns) = revCount' cs ns ++ replicate n c
 
-repeat' :: Char -> Int -> [Char]
+repeat' :: a -> Int -> [a]
 repeat' _ 0 = []
-repeat' c n = [c] ++ (repeat' c (n-1))
+repeat' c n = c : repeat' c (n-1)
+
+repeat'' ::  a -> Int -> [a]
+repeat'' = flip replicate


### PR DESCRIPTION
1. Use `:` instead of `++` to prepend single items - O(1) rather than O(n)
2. Non-exhaustive patterns in function `afterFilter`
3. `nxs` can be replaced with `y:xs`
4. `revCount` is polymorphic, doesn't need to be restricted to
   `String`s.
5. `revCount` should return a single list, not a list of lists.
6. Non-exhaustive patterns in function `revCount'`
7. `repeat' = flip replicate`

Try using `ghci -Wall -i Whatever.hs` to see any possible errors - useful for
pattern match errors. Also `hlint` to spot simple syntax improvements which can
be installed using `cabal install hlint`.

The output of `afterFilter` was originally wrong; it should return a list of
elements that succeed a match. Originally it would return the head of the list
of the predicate did not match; for example:

``` haskell
ghci λ> afterFilter (\n -> n `mod` 5 == 0) [1..15]
[1,2,3,4,6,7,8,9,11,12,13,14]
```

Where it should have been:

``` haskell
ghci λ: afterFilter (\n -> n `mod` 5 == 0) [1..15]
[6,11]
```
